### PR TITLE
Settings are saved when brackets are closed.

### DIFF
--- a/main.js
+++ b/main.js
@@ -7,17 +7,19 @@ define(function (require, exports, module) {
     "use strict";
 
     // Brackets modules
-    var	Commands        = brackets.getModule('command/Commands'),
-        CommandManager  = brackets.getModule('command/CommandManager'),
-        DocumentManager = brackets.getModule('document/DocumentManager'),
-        EditorManager   = brackets.getModule('editor/EditorManager'),
-        StringUtils     = brackets.getModule('utils/StringUtils'),
-        Menus           = brackets.getModule('command/Menus');
+    var Commands            = brackets.getModule('command/Commands'),
+        CommandManager      = brackets.getModule('command/CommandManager'),
+        DocumentManager     = brackets.getModule('document/DocumentManager'),
+        EditorManager       = brackets.getModule('editor/EditorManager'),
+        PreferencesManager  = brackets.getModule("preferences/PreferencesManager"),
+        StringUtils         = brackets.getModule('utils/StringUtils'),
+        Menus               = brackets.getModule('command/Menus');
 
     // Extension variables
     var EXT_ID          = 'org.pockata.stripTrailingSpaces',
         settings        = require('settings'),
-        shouldStrip     = !!settings.autostrip,
+        preferences     = PreferencesManager.getPreferenceStorage(module, settings),
+        shouldStrip     = preferences.getValue("autostrip"),
         strippedOnce    = false, // needed for documentSaved loop.
         menu            = Menus.getMenu(Menus.AppMenuBar.EDIT_MENU);
 
@@ -110,6 +112,7 @@ define(function (require, exports, module) {
         // Register command
         var cmd = CommandManager.register('Strip trailing spaces', EXT_ID, function () {
             shouldStrip = !shouldStrip;
+            preferences.setValue("autostrip", shouldStrip);
             cmd.setChecked(shouldStrip);
         });
 


### PR DESCRIPTION
Leaves the option in the menu checked/unchecked depending on the state it was left before closing brackets.
